### PR TITLE
Expose Api Errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     BadMedia,
     NoUserData,
     TooManyRequests,
+    ApiError(String),
     Unknown
 }
 
@@ -16,6 +17,7 @@ impl fmt::Display for Error {
             Error::Reqwest(ref err) => write!(f, "HTTP request error: {}", err),
             Error::BadMedia => write!(f, "faulty media"),
             Error::NoUserData => write!(f, "No user data found"),
+            Error::ApiError(ref str) => write!(f, "Api Error: {}", str),
             Error::Unknown => write!(f, "unknown"),
             Error::TooManyRequests => write!(f, "too many reqs"),
         }
@@ -28,6 +30,7 @@ impl error::Error for Error {
             Error::Reqwest(ref err) => Some(err),
             Error::BadMedia => None,
             Error::NoUserData => None,
+            Error::ApiError(_) => None,
             Error::Unknown => None,
             Error::TooManyRequests => None,
         }


### PR DESCRIPTION
Simple fix for #3 

Keep the same behaviour, but when the error is not in the ```Error``` enum, simply return all the text from it